### PR TITLE
Don't choke on HTTPS domains

### DIFF
--- a/lib/site-inspector.rb
+++ b/lib/site-inspector.rb
@@ -23,7 +23,7 @@ class SiteInspector
 
   def initialize(domain)
     domain = domain.downcase
-    domain = domain.sub /^http\:/, ""
+    domain = domain.sub /^https?\:/, ""
     domain = domain.sub /^\/+/, ""
     domain = domain.sub /^www\./, ""
     @uri = Addressable::URI.parse "//#{domain}"


### PR DESCRIPTION
The inspector is fine being initialized with an `http://` URL, it'll strip the protocol off -- but was choking on `https://`. This uses the power of regular expressions to empower us all.
