### PR TITLE
has_cookies method isn't accurate

### DIFF
--- a/lib/site-inspector/headers.rb
+++ b/lib/site-inspector/headers.rb
@@ -1,8 +1,9 @@
 class SiteInspector
 
-  # the ? versions could maybe just be dropped
+  # cookies can have multiple set-cookie headers, so this detects
+  # whether cookies are set, but not all their values.
   def has_cookies?
-    !!has_cookies
+    !!header_from("Set-Cookie")
   end
 
   def strict_transport_security?
@@ -18,10 +19,6 @@ class SiteInspector
   end
 
   # return the found header value
-
-  def has_cookies
-    header_from("Set-Cookie")
-  end
 
   def strict_transport_security
     header_from("Strict-Transport-Security")

--- a/test/test_site_inspector_headers.rb
+++ b/test/test_site_inspector_headers.rb
@@ -13,7 +13,6 @@ class TestSiteInspectorHeaders < Minitest::Test
     VCR.use_cassette "ed.gov", :record => :new_episodes do
       site = SiteInspector.new "ed.gov"
       assert_equal false, site.has_cookies?
-      assert_nil site.has_cookies
     end
   end
 
@@ -21,7 +20,6 @@ class TestSiteInspectorHeaders < Minitest::Test
     VCR.use_cassette "cio.gov", :record => :new_episodes do
       site = SiteInspector.new "cio.gov"
       assert_equal true, site.has_cookies?
-      assert !site.has_cookies.nil? # uses a generated ID
     end
   end
 


### PR DESCRIPTION
I didn't think this one through - websites can have multiple Set-Cookie headers, so I'm yanking this one. It wasn't publicly documented, so there's no urgent harm.
