### PR TITLE
Prefetch all endpoints prior to calculating to_h

### DIFF
--- a/lib/site-inspector/checks/headers.rb
+++ b/lib/site-inspector/checks/headers.rb
@@ -66,7 +66,7 @@ class SiteInspector
 
       # Returns an array of hashes of downcased key/value header pairs (or an empty hash)
       def all
-        @all ||= response ? Hash[response.headers.map{ |k,v| [k.downcase,v] }] : {}
+        @all ||= (response && response.headers) ? Hash[response.headers.map{ |k,v| [k.downcase,v] }] : {}
       end
       alias_method :headers, :all
 

--- a/spec/checks/site_inspector_endpoint_headers_spec.rb
+++ b/spec/checks/site_inspector_endpoint_headers_spec.rb
@@ -79,7 +79,7 @@ describe SiteInspector::Endpoint::Headers do
   end
 
   it "knows when an endpoint doesn't return a proper 404" do
-    stub_request(:get, /http\:\/\/example.com\/.*/).
+    stub_request(:get, /http\:\/\/example.com\/[a-z0-9]{32}/i).
       to_return(:status => 200)
     expect(subject.proper_404s?).to eql(false)
   end


### PR DESCRIPTION
We know most API calls to the domain model are going to require That the root of all four endpoints are called. Rather than process them In serial, lets grab them in parallel and cache the results to speed up later calls.