### PR TITLE
Update headers.rb, fixes warning

### DIFF
--- a/lib/site-inspector/checks/headers.rb
+++ b/lib/site-inspector/checks/headers.rb
@@ -72,7 +72,6 @@ class SiteInspector
           :strict_transport_security => strict_transport_security || false,
           :content_security_policy => content_security_policy || false,
           :click_jacking_protection => click_jacking_protection || false,
-          :click_jacking_protection => click_jacking_protection || false,
           :server => server,
           :xss_protection => xss_protection || false,
           :secure_cookies => secure_cookies?


### PR DESCRIPTION
Remove duplicate key for :click_jacking_protection. Existing code was throwing a warning.