### PR TITLE
Fix "canoncial" typo

### DIFF
--- a/lib/site-inspector/domain.rb
+++ b/lib/site-inspector/domain.rb
@@ -205,7 +205,7 @@ class SiteInspector
     # Returns a complete hash of the domain's information
     def to_h(options={})
       prefetch
-      
+
       hash = {
         host:               host,
         up:                 up?,
@@ -220,7 +220,7 @@ class SiteInspector
         hsts:               hsts?,
         hsts_subdomains:    hsts_subdomains?,
         hsts_preload_ready: hsts_preload_ready?,
-        canoncial_endpoint: canonical_endpoint.to_h(options)
+        canonical_endpoint: canonical_endpoint.to_h(options)
       }
 
       if options["all"]


### PR DESCRIPTION
Hash key copy editor reporting for duty.

Small as it is, since this is a dict/JSON key typo, this is technically a backwards-incompatible change. I'm not sure whether it's worth sticking with strict semver and bumping to 3.0, if 2.0's not in much use in the wild.

I think that as I dive into the site-inspector refactor from 1.0.2 -> 2.0.0, I'm likely to suggest further backwards-incompatible changes. I'm submitting this as a PR to a `2.1` branch, not to `master`, to offer the opportunity to grapple with them all at once.

That said, I know large-scale non-incremental refactors are a software engineering nightmare. So if you'd like to push this directly to `master` and go from there, :+1: too.