### PR TITLE
Fix disk cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 
 /.env
 /tmp
+/cache

--- a/lib/site-inspector/disk_cache.rb
+++ b/lib/site-inspector/disk_cache.rb
@@ -32,7 +32,7 @@ class SiteInspector
     private
 
     def path(request)
-      File.join(@dir, request)
+      File.join(@dir, request.cache_key)
     end
   end
 end

--- a/spec/site_inspector_disk_cache_spec.rb
+++ b/spec/site_inspector_disk_cache_spec.rb
@@ -2,30 +2,36 @@ require 'spec_helper'
 
 describe SiteInspector::DiskCache do
   subject { SiteInspector::DiskCache.new(tmpdir) }
-  
+
   before do
     FileUtils.rm_rf(tmpdir)
     Dir.mkdir(tmpdir)
   end
 
   it "should write a value to disk" do
-    path = File.expand_path "foo", tmpdir
+    foo = Typhoeus::Request.new("foo")
+
+    path = File.expand_path foo.cache_key, tmpdir
     expect(File.exists?(path)).to eql(false)
 
-    subject.set "foo", "bar"
+    subject.set foo, "bar"
 
     expect(File.exists?(path)).to eql(true)
     expect(File.open(path).read).to eql("I\"bar:ET")
   end
 
   it "should read a value from disk" do
-    path = File.expand_path "foo", tmpdir
+    foo = Typhoeus::Request.new("foo")
+
+    path = File.expand_path foo.cache_key, tmpdir
     File.write(path, "I\"bar:ET")
-    expect(subject.get("foo")).to eql("bar")
+    expect(subject.get(foo)).to eql("bar")
   end
 
   it "should calculate a file's path" do
-    path = File.expand_path "foo", tmpdir
-    expect(subject.send(:path, "foo")).to eql(path)
+    foo = Typhoeus::Request.new("foo")
+
+    path = File.expand_path foo.cache_key, tmpdir
+    expect(subject.send(:path, foo)).to eql(path)
   end
 end


### PR DESCRIPTION
The memory cache can use a `Typhoeus::Request` object itself as the hash key, but the disk cache has to name files with a simple string. The disk cache was doing this by building the cache path from the request object's `cache_key`, but it somehow got dropped in https://github.com/benbalter/site-inspector/commit/cbd847ef9f858cf010d1f9a1bd74a62c07fb768d during the 2.0 refactor. This caused site-inspector to break when the disk cache was used.

I've also `.gitignore`'d the use of a `/cache` directory in the project root, as a convenience for debug/development.