### PR TITLE
Accessibility check tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Gemfile.lock
 /tmp
 
 mkmf.log
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ rvm:
 script: "script/cibuild"
 sudo: false
 cache: bundler
+before_script: npm install -g pa11y

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
 script: "script/cibuild"
 sudo: false
 cache: bundler
-before_script: npm install -g pa11y
+before_script: npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ rvm:
   - 2.1
 script: "script/cibuild"
 sudo: false
-cache: bundler
+cache:
+  - bundler
+  - "node_modules"
 before_script: npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ script: "script/cibuild"
 sudo: false
 cache:
   - bundler
-  - "node_modules"
+  - node_modules
 before_script: npm install

--- a/lib/site-inspector/checks/accessibility.rb
+++ b/lib/site-inspector/checks/accessibility.rb
@@ -38,7 +38,11 @@ class SiteInspector
       end
 
       def valid?
-        pa11y(standard)[:status] == :valid
+        check[:valid]
+      end
+
+      def check
+        pa11y(standard)
       end
 
       def pa11y_version
@@ -85,7 +89,7 @@ class SiteInspector
         raise "Command `pa11y #{args.join(" ")}` failed: #{output}" if status == 1
 
         {
-          status:  status == 0 ? :valid : :invalid,
+          valid:   status == 0,
           results: JSON.parse(output)
         }
       end

--- a/lib/site-inspector/checks/accessibility.rb
+++ b/lib/site-inspector/checks/accessibility.rb
@@ -13,14 +13,14 @@ class SiteInspector
         wcag2aaa:   'WCAG2AAA'
       }
 
-      DEFAULT_LEVEL = "error"
+      DEFAULT_LEVEL = :error
 
       def level
         @level ||= DEFAULT_LEVEL
       end
 
       def level=(level)
-        raise ArgumentError, "Invalid level '#{level}'" unless %w[error warning notice].include?(level)
+        raise ArgumentError, "Invalid level '#{level}'" unless [:error, :warning, :notice].include?(level)
         @level = level
       end
 
@@ -79,7 +79,7 @@ class SiteInspector
         args = [
           "--standard", STANDARDS[standard],
           "--reporter", "json",
-          "--level", level,
+          "--level",    level.to_s,
           endpoint.uri.to_s
         ]
         output, status = Open3.capture2e("pa11y", *args)

--- a/lib/site-inspector/checks/accessibility.rb
+++ b/lib/site-inspector/checks/accessibility.rb
@@ -20,7 +20,7 @@ class SiteInspector
       end
 
       def level=(level)
-        raise ArgumentError, "Invalid level '#{level}'" unless %w[error, warning, notice].include?(level)
+        raise ArgumentError, "Invalid level '#{level}'" unless %w[error warning notice].include?(level)
         @level = level
       end
 

--- a/lib/site-inspector/checks/accessibility.rb
+++ b/lib/site-inspector/checks/accessibility.rb
@@ -5,58 +5,90 @@ require 'mkmf'
 class SiteInspector
   class Endpoint
     class Accessibility < Check
-      
-      def section508
-        pa11y(:section508)
+
+      STANDARDS = {
+        section508: 'Section508', # Default standard
+        wcag2a:     'WCAG2A',
+        wcag2aa:    'WCAG2AA',
+        wcag2aaa:   'WCAG2AAA'
+      }
+
+      DEFAULT_LEVEL = "error"
+
+      def level
+        @level ||= DEFAULT_LEVEL
       end
-      
-      def wcag2a
-        pa11y(:wcag2a)
+
+      def level=(level)
+        raise ArgumentError, "Invalid level '#{level}'" unless %w[error, warning, notice].include?(level)
+        @level = level
       end
-      
-      def wcag2aa
-        pa11y(:wcag2aa)
+
+      def standard?(standard)
+        STANDARDS.keys.include?(standard)
       end
-      
-      def wcag2aaa
-        pa11y(:wcag2aaa)
+
+      def standard
+        @standard ||= STANDARDS.keys.first
       end
-      
-      private
-      
-      def pa11y_installed?
-        !`which pa11y`.empty?
+
+      def standard=(standard)
+        raise ArgumentError, "Unknown standard '#{standard}'" unless standard?(standard)
+        @standard = standard
       end
-      
-      def pa11y(standard)
-        if pa11y_installed?
-          standards = {
-            section508: 'Section508',
-            wcag2a: 'WCAG2A',
-            wcag2aa: 'WCAG2AA',
-            wcag2aaa: 'WCAG2AAA'
-          }
-          standard = standards[standard]
-                             
-          cmd = "pa11y #{endpoint.uri} -s #{standard} -r json"
-          response = ""
-          error = nil
-                  
-          Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
-            response = stdout.read
-            error = stderr.read          
-          end    
-        
-          if error && !error.empty?
-            raise error
-          end
-        
-          JSON.parse(response) 
+
+      def valid?
+        pa11y(standard)[:status] == :valid
+      end
+
+      def pa11y_version
+        output, status = Open3.capture2e("pa11y", "--version")
+        output.strip if status == 0
+      end
+
+      def pa11y?
+        !pa11y_version.nil?
+      end
+
+      def method_missing(method_sym, *arguments, &block)
+        if standard?(method_sym)
+          pa11y(method_sym)
         else
-          raise "pa11y not found. To install: [sudo] npm install -g pa11y"
+          super
         end
       end
-      
+
+      def respond_to?(method_sym, include_private = false)
+        if standard?(method_sym)
+          true
+        else
+          super
+        end
+      end
+
+      private
+
+      def pa11y(standard)
+        raise "pa11y not found. To install: [sudo] npm install -g pa11y" unless pa11y?
+        raise ArgumentError, "Unknown standard '#{standard}'" unless standard?(standard)
+
+        args = [
+          "--standard", STANDARDS[standard],
+          "--reporter", "json",
+          "--level", level,
+          endpoint.uri.to_s
+        ]
+        output, status = Open3.capture2e("pa11y", *args)
+
+        # Pa11y exit codes: https://github.com/nature/pa11y#exit-codes
+        # 0: No errors, 1: Technical error within pa11y, 2: accessibility error (configurable via --level)
+        raise "Command `pa11y #{args.join(" ")}` failed: #{output}" if status == 1
+
+        {
+          status:  status == 0 ? :valid : :invalid,
+          results: JSON.parse(output)
+        }
+      end
     end
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "site-inspector",
+  "version": "2.0.0",
+  "description": "Returns information about a domain's technology and capabilities",
+  "main": "site-inspector",
+  "dependencies": {
+    "pa11y": "^2.1.0"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "script/cibuild"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/benbalter/site-inspector.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/benbalter/site-inspector/issues"
+  },
+  "homepage": "https://github.com/benbalter/site-inspector#readme"
+}

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,1 +1,2 @@
 bundle install
+npm install

--- a/script/cibuild
+++ b/script/cibuild
@@ -2,6 +2,8 @@
 
 set -e
 
+echo "Pa11y version: $(pa11y --version)"
+
 bundle exec rake spec
 
 gem build site-inspector.gemspec

--- a/spec/checks/site_inspector_endpoint_accessibility_spec.rb
+++ b/spec/checks/site_inspector_endpoint_accessibility_spec.rb
@@ -49,11 +49,31 @@ describe SiteInspector::Endpoint::Accessibility do
     it "knows if pa11y is installed" do
       expect(subject.pa11y?).to eql(true)
     end
+
+    it "knows if a site is valid" do
+      expect(subject.valid?).to eql(true)
+    end
+
+    it "runs the check" do
+      expected = {
+        valid: true,
+        results: []
+      }
+      expect(subject.check).to eql(expected)
+    end
+
+    it "runs a named check" do
+      expected = {
+        valid: true,
+        results: []
+      }
+      expect(subject.section508).to eql(expected)
+    end
   end
 
   context "without pa11y installed" do
     before do
-      subject.stub(:pa11y_version) { nil }
+      allow(subject).to receive(:pa11y_version) { nil }
     end
 
     it "knows when pa11y insn't installed" do

--- a/spec/checks/site_inspector_endpoint_accessibility_spec.rb
+++ b/spec/checks/site_inspector_endpoint_accessibility_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 describe SiteInspector::Endpoint::Accessibility do
 
   before do
-    stub_request(:get, "https://example.com/").to_return(:status => 200 )
+    stub_request(:get, "http://example.com/").to_return(:status => 200 )
   end
 
   subject do
-    endpoint = SiteInspector::Endpoint.new("https://example.com")
+    endpoint = SiteInspector::Endpoint.new("http://example.com")
     SiteInspector::Endpoint::Accessibility.new(endpoint)
   end
 

--- a/spec/checks/site_inspector_endpoint_accessibility_spec.rb
+++ b/spec/checks/site_inspector_endpoint_accessibility_spec.rb
@@ -2,18 +2,62 @@ require 'spec_helper'
 
 describe SiteInspector::Endpoint::Accessibility do
 
+  before do
+    stub_request(:get, "https://example.com/").to_return(:status => 200 )
+  end
+
   subject do
-    stub_request(:get, "https://example.com/").
-      to_return(:status => 200 )
     endpoint = SiteInspector::Endpoint.new("https://example.com")
-    
-    # allow(endpoint.response).to receive(:return_code) { :ok }
-    
     SiteInspector::Endpoint::Accessibility.new(endpoint)
   end
 
-  # it "knows the scheme" do
-  #   expect(subject.send(:scheme)).to eql("https")
-  # end
+  it "retrieve's pa11y's version" do
+    expect(subject.pa11y_version).to match(/\d\.\d\.\d/)
+  end
 
+  it "responds to valid standards" do
+    expect(subject.respond_to?(:section508)).to eql(true)
+  end
+
+  it "knows the level" do
+    expect(subject.level).to eql("error")
+  end
+
+  it "allows the user to set the level" do
+    subject.level = "warning"
+    expect(subject.level).to eql("warning")
+  end
+
+  it "errors on invalid levels" do
+    expect{subject.level="foo"}.to raise_error(ArgumentError)
+  end
+
+  it "knows the standard" do
+    expect(subject.standard).to eql(:section508)
+  end
+
+  it "allows the user to set the standard" do
+    subject.standard = :wcag2a
+    expect(subject.standard).to eql(:wcag2a)
+  end
+
+  it "errors on invalid standards" do
+    expect{subject.standard=:foo}.to raise_error(ArgumentError)
+  end
+
+  context "with pa11y installed" do
+    it "knows if pa11y is installed" do
+      expect(subject.pa11y?).to eql(true)
+    end
+  end
+
+  context "without pa11y installed" do
+    before do
+      subject.stub(:pa11y_version) { nil }
+    end
+
+    it "knows when pa11y insn't installed" do
+      expect(subject.pa11y?).to eql(false)
+    end
+  end
 end

--- a/spec/checks/site_inspector_endpoint_accessibility_spec.rb
+++ b/spec/checks/site_inspector_endpoint_accessibility_spec.rb
@@ -2,10 +2,6 @@ require 'spec_helper'
 
 describe SiteInspector::Endpoint::Accessibility do
 
-  before do
-    stub_request(:get, "http://example.com/").to_return(:status => 200 )
-  end
-
   subject do
     endpoint = SiteInspector::Endpoint.new("http://example.com")
     SiteInspector::Endpoint::Accessibility.new(endpoint)
@@ -46,6 +42,11 @@ describe SiteInspector::Endpoint::Accessibility do
   end
 
   context "with pa11y installed" do
+
+    before do
+      stub_request(:get, "http://example.com/").to_return(:status => 200 )
+    end
+    
     it "knows if pa11y is installed" do
       expect(subject.pa11y?).to eql(true)
     end

--- a/spec/checks/site_inspector_endpoint_accessibility_spec.rb
+++ b/spec/checks/site_inspector_endpoint_accessibility_spec.rb
@@ -79,5 +79,9 @@ describe SiteInspector::Endpoint::Accessibility do
     it "knows when pa11y insn't installed" do
       expect(subject.pa11y?).to eql(false)
     end
+
+    it "fails loudly withouy pa11y" do
+      expect{subject.check}.to raise_error("pa11y not found. To install: [sudo] npm install -g pa11y")
+    end
   end
 end

--- a/spec/checks/site_inspector_endpoint_accessibility_spec.rb
+++ b/spec/checks/site_inspector_endpoint_accessibility_spec.rb
@@ -16,12 +16,12 @@ describe SiteInspector::Endpoint::Accessibility do
   end
 
   it "knows the level" do
-    expect(subject.level).to eql("error")
+    expect(subject.level).to eql(:error)
   end
 
   it "allows the user to set the level" do
-    subject.level = "warning"
-    expect(subject.level).to eql("warning")
+    subject.level = :warning
+    expect(subject.level).to eql(:warning)
   end
 
   it "errors on invalid levels" do
@@ -46,7 +46,7 @@ describe SiteInspector::Endpoint::Accessibility do
     before do
       stub_request(:get, "http://example.com/").to_return(:status => 200 )
     end
-    
+
     it "knows if pa11y is installed" do
       expect(subject.pa11y?).to eql(true)
     end


### PR DESCRIPTION
@adelevie this is a pull request against #39, implementing some of the things I suggestion on the line-by-line, plus a few tweaks I found once in the code. Specifically:

* Add a `package.json` file to make installing and versioning Pa11y in development and test a bit easier
* Move the standards to a class constant
* Move the individual checks to a magic method to DRY things up
* Simplify how we shell out to Pa11y and respect it's exit code
* Guard against invalid standards
* Added a `standard?` method
* Check for Pa11y existence via `pa11y --version` so we know it actually executes
* Made things a bit more object-oriented and deterministic
  * The accessibility object now has `level` and `standard` getters and setters, defaulting to `508` and `error`.
  * This allows us to expose a `valid?` method, and
  * Allows the pa11y response object to also return a `valid` key
  * So that when used, e.g., via CI, we have a binary output, rather than an array of feedbacks

Feel free to merge into your branch, if things look :+1:, or glad to go into more detail on any/all of the above.