### PR TITLE
Restore the difference between "live" and "up"

### DIFF
--- a/lib/site-inspector/endpoint.rb
+++ b/lib/site-inspector/endpoint.rb
@@ -56,11 +56,6 @@ class SiteInspector
       @response ||= request
     end
 
-    # Does the server return any response? (including 50x)
-    def response?
-       response.code != 0 && !timed_out?
-    end
-
     def response_code
       response.response_code.to_s if response
     end
@@ -70,21 +65,13 @@ class SiteInspector
     end
 
     # Does the endpoint return a 2xx or 3xx response code?
-    def live?
+    def up?
       response && response_code.start_with?("2") || response_code.start_with?("3")
     end
 
-    def dead?
-      !live?
-    end
-
-    # Does the domain respond to HTTP?
-    def up?
-      response?
-    end
-
-    def down?
-      !up?
+    # Does the server respond at all?
+    def responds?
+       response.code != 0 && !timed_out?
     end
 
     # If the domain is a redirect, what's the first endpoint we're redirected to?

--- a/lib/site-inspector/endpoint.rb
+++ b/lib/site-inspector/endpoint.rb
@@ -70,8 +70,17 @@ class SiteInspector
     end
 
     # Does the endpoint return a 2xx or 3xx response code?
-    def up?
+    def live?
       response && response_code.start_with?("2") || response_code.start_with?("3")
+    end
+
+    def dead?
+      !live?
+    end
+
+    # Does the domain respond to HTTP?
+    def up?
+      response?
     end
 
     def down?
@@ -155,6 +164,7 @@ class SiteInspector
         https: https?,
         scheme: scheme,
         up: up?,
+        live: live?,
         timed_out: timed_out?,
         redirect: redirect?,
         external_redirect: external_redirect?,

--- a/spec/site_inspector_domain_spec.rb
+++ b/spec/site_inspector_domain_spec.rb
@@ -89,23 +89,23 @@ describe SiteInspector::Domain do
     end
   end
 
-  context "live" do
-    it "considers a domain live if at least one endpoint is dead" do
+  context "up" do
+    it "considers a domain up if at least one endpoint is up" do
       stub_request(:get, "https://example.com/").to_return(:status => 500)
       stub_request(:get, "https://www.example.com/").to_return(:status => 500)
       stub_request(:get, "http://example.com/").to_return(:status => 500)
       stub_request(:get, "http://www.example.com/").to_return(:status => 200)
 
-      expect(subject.live?).to eql(true)
+      expect(subject.up?).to eql(true)
     end
 
-    it "doesn't consider a domain live when all endpoints are dead" do
+    it "doesn't consider a domain up if all endpoints are down" do
       stub_request(:get, "https://example.com/").to_return(:status => 500)
       stub_request(:get, "https://www.example.com/").to_return(:status => 500)
       stub_request(:get, "http://example.com/").to_return(:status => 500)
       stub_request(:get, "http://www.example.com/").to_return(:status => 500)
 
-      expect(subject.live?).to eql(false)
+      expect(subject.up?).to eql(false)
     end
   end
 
@@ -116,7 +116,7 @@ describe SiteInspector::Domain do
       stub_request(:get, "http://example.com/").to_return(:status => 500)
       stub_request(:get, "http://www.example.com/").to_return(:status => 200)
 
-      expect(subject.up?).to eql(true)
+      expect(subject.www?).to eql(true)
     end
 
     it "doesn't consider a site www when no endpoint is www" do
@@ -125,7 +125,7 @@ describe SiteInspector::Domain do
       stub_request(:get, "http://example.com/").to_return(:status => 200)
       stub_request(:get, "http://www.example.com/").to_return(:status => 500)
 
-      expect(subject.up?).to eql(true)
+      expect(subject.www?).to eql(false)
     end
   end
 

--- a/spec/site_inspector_endpoint_spec.rb
+++ b/spec/site_inspector_endpoint_spec.rb
@@ -96,15 +96,15 @@ describe SiteInspector::Endpoint do
       stub_request(:get, "http://example.com/").
            to_return(:status => 200, :body => "content")
 
-      expect(subject.response?).to eql(true)
+      expect(subject.responds?).to eql(true)
     end
 
     it "knows when there's not a response" do
       allow(subject).to receive(:response) { Typhoeus::Response.new(code: 0) }
-      expect(subject.response?).to eql(false)
+      expect(subject.responds?).to eql(false)
 
       allow(subject).to receive(:response) { Typhoeus::Response.new(:return_code => :operation_timedout) }
-      expect(subject.response?).to eql(false)
+      expect(subject.responds?).to eql(false)
     end
 
     it "knows the response code" do
@@ -119,68 +119,50 @@ describe SiteInspector::Endpoint do
       expect(subject.timed_out?).to eql(true)
     end
 
-    it "considers a 200 response code to be live and up" do
+    it "considers a 200 response code to be live and a response" do
       stub_request(:get, "http://example.com/").
            to_return(:status => 200)
 
-      expect(subject.live?).to eql(true)
-      expect(subject.dead?).to eql(false)
-
       expect(subject.up?).to eql(true)
-      expect(subject.down?).to eql(false)
+      expect(subject.responds?).to eql(true)
     end
 
-    it "considers a 301 response code to be live and up" do
+    it "considers a 301 response code to be live and a response" do
       stub_request(:get, "http://example.com/").
            to_return(:status => 301)
 
-      expect(subject.live?).to eql(true)
-      expect(subject.dead?).to eql(false)
-
       expect(subject.up?).to eql(true)
-      expect(subject.down?).to eql(false)
+      expect(subject.responds?).to eql(true)
     end
 
-    it "considers a 404 response code to be dead but up" do
+    it "considers a 404 response code to be down but a response" do
       stub_request(:get, "http://example.com/").
            to_return(:status => 404)
 
-      expect(subject.live?).to eql(false)
-      expect(subject.dead?).to eql(true)
-
-      expect(subject.up?).to eql(true)
-      expect(subject.down?).to eql(false)
+      expect(subject.up?).to eql(false)
+      expect(subject.responds?).to eql(true)
     end
 
-    it "considers a 500 response code to be dead but up" do
+    it "considers a 500 response code to be down but a response" do
       stub_request(:get, "http://example.com/").
            to_return(:status => 500)
 
-      expect(subject.live?).to eql(false)
-      expect(subject.dead?).to eql(true)
-
-      expect(subject.up?).to eql(true)
-      expect(subject.down?).to eql(false)
+      expect(subject.up?).to eql(false)
+      expect(subject.responds?).to eql(true)
     end
 
-    it "considers a 0 response code (error) to be dead and down" do
+    it "considers a 0 response code (error) to down and unresponsive" do
       allow(subject).to receive(:response) { Typhoeus::Response.new(code: 0) }
 
-      expect(subject.live?).to eql(false)
-      expect(subject.dead?).to eql(true)
-
       expect(subject.up?).to eql(false)
-      expect(subject.down?).to eql(true)
+      expect(subject.responds?).to eql(false)
     end
 
-    it "considers a timeout to be dead and down" do
+    it "considers a timeout to be down and unresponsive" do
       allow(subject).to receive(:response) { Typhoeus::Response.new(:return_code => :operation_timedout) }
 
-      expect(subject.live?).to eql(false)
-      expect(subject.dead?).to eql(true)
-
       expect(subject.up?).to eql(false)
-      expect(subject.down?).to eql(true)
+      expect(subject.responds?).to eql(false)
     end
   end
 


### PR DESCRIPTION
In site-inspector 1.X, "live" meant a 2XX response code. It would mean `!!response`, where `response` would be truthy if `response.success?` was true, and `false` if the response was nil or failed.

In 1.0.2, I added "up", which meant: "Is this domain/endpoint reachable over HTTP at all?" Even an endpoint that returned a 500 response code was "up" in the sense that the site responded to connections.

There are various cases where it's valuable to measure whether a domain responds to HTTP at all, and to distinguish an unreachable endpoint from an endpoint which just has a [404 page lying around](https://www.nist.gov/).

In 2.0, "live" got renamed to "up", which changed the intended meaning of "up". This pull request separates their definitions again:

```ruby
    # Does the endpoint return a 2xx or 3xx response code?
    def live?
      response && response_code.start_with?("2") || response_code.start_with?("3")
    end

    def dead?
      !live?
    end

    # Does the domain respond to HTTP?
    def up?
      response?
    end

    def down?
      !up?
    end
```

```ruby
    def response?
       response.code != 0 && !timed_out?
    end
```

The domain-wide calculation is still the same: a domain is "live" if any of its endpoints are "live", and "up" if any of its endpoints are "up". The tests are updated as well.

In this pull request, I left alone the downstream decisions that depend on live/up, like whether an endpoint is "canonical". Those will likely be changed in a subsequent PR, because the canonicality definitions I created for 1.0.2 were sometimes premised on an endpoint being reachable, sometimes premised on an endpoint having a 20X.