### PR TITLE
Only run "enabled" checks

### DIFF
--- a/lib/site-inspector/checks/accessibility.rb
+++ b/lib/site-inspector/checks/accessibility.rb
@@ -53,6 +53,7 @@ class SiteInspector
       def pa11y?
         !pa11y_version.nil?
       end
+      alias_method :enabled?, :pa11y?
 
       def method_missing(method_sym, *arguments, &block)
         if standard?(method_sym)

--- a/lib/site-inspector/checks/check.rb
+++ b/lib/site-inspector/checks/check.rb
@@ -36,6 +36,10 @@ class SiteInspector
       def self.name
         self.to_s.split('::').last.downcase.to_sym
       end
+
+      def enabled?
+        true
+      end
     end
   end
 end

--- a/lib/site-inspector/endpoint.rb
+++ b/lib/site-inspector/endpoint.rb
@@ -160,7 +160,8 @@ class SiteInspector
       # Either they've specifically asked for a check, or we throw everything at them
       checks = SiteInspector::Endpoint.checks.select { |c| options.keys.include?(c.name) }
       checks = SiteInspector::Endpoint.checks if checks.empty?
-
+      checks.select { |check| check.enabled? }
+      
       checks.each do |check|
         hash[check.name] = self.send(check.name).to_h
       end

--- a/spec/checks/site_inspector_endpoint_check_spec.rb
+++ b/spec/checks/site_inspector_endpoint_check_spec.rb
@@ -31,4 +31,8 @@ describe SiteInspector::Endpoint::Check do
   it "returns the instance name" do
     expect(SiteInspector::Endpoint::Check.name).to eql(:check)
   end
+
+  it "enables the check" do
+    expect(subject.enabled).to eql(true)
+  end
 end

--- a/spec/checks/site_inspector_endpoint_check_spec.rb
+++ b/spec/checks/site_inspector_endpoint_check_spec.rb
@@ -33,6 +33,6 @@ describe SiteInspector::Endpoint::Check do
   end
 
   it "enables the check" do
-    expect(subject.enabled).to eql(true)
+    expect(subject.enabled?).to eql(true)
   end
 end


### PR DESCRIPTION
This prevents the pa11y check from running by default when pa11y isn't installed.