### PR TITLE
Better framework sniffing

### DIFF
--- a/lib/site-inspector.rb
+++ b/lib/site-inspector.rb
@@ -2,6 +2,7 @@ require 'open-uri'
 require 'addressable/uri'
 require 'public_suffix'
 require 'typhoeus'
+require 'cgi'
 
 require_relative 'site-inspector/cache'
 require_relative 'site-inspector/disk_cache'

--- a/lib/site-inspector/checks/headers.rb
+++ b/lib/site-inspector/checks/headers.rb
@@ -8,6 +8,10 @@ class SiteInspector
         !!headers["set-cookie"]
       end
 
+      def cookies
+        headers["set-cookie"].map { |c| CGI::Cookie::parse(c) } if cookies?
+      end
+
       # TODO: kill this
       def strict_transport_security?
         !!strict_transport_security
@@ -50,7 +54,7 @@ class SiteInspector
       end
 
       def secure_cookies?
-        return false if !cookies?
+        return false unless cookies?
         cookie = headers["set-cookie"]
         cookie = cookie.first if cookie.is_a?(Array)
         !!(cookie =~ /(; secure.*; httponly|; httponly.*; secure)/i)

--- a/spec/checks/site_inspector_endpoint_sniffer_spec.rb
+++ b/spec/checks/site_inspector_endpoint_sniffer_spec.rb
@@ -2,51 +2,96 @@ require 'spec_helper'
 
 describe SiteInspector::Endpoint::Sniffer do
 
-  subject do
-    body = <<-eos
-      <html>
-        <head>
-          <link rel='stylesheet' href='/wp-content/themes/foo/style.css type='text/css' media='all' />
-        </head>
-        <body>
-          <h1>Some page</h1>
-          <script>
-            jQuery(); googletag.pubads();
-          </script>
-          <script>
-            var _gaq=[['_setAccount','UA-12345678-1'],['_trackPageview']];
-            (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-            g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
-            s.parentNode.insertBefore(g,s)}(document,'script'));
-          </script>
-        </body>
-      </html>
-    eos
-
-    stub_request(:get, "http://example.com/").
-      to_return(:status => 200, :body => body )
-    endpoint = SiteInspector::Endpoint.new("http://example.com")
-    SiteInspector::Endpoint::Sniffer.new(endpoint)
+  def stub_header(header, value)
+    allow(subject.endpoint.headers).to receive(:headers) { { header => value } }
   end
 
-  it "sniffs" do
-    sniff = subject.send(:sniff, :cms)
-    expect(sniff.keys.first).to eql(:wordpress)
+  def set_cookie(key, value)
+    cookies = [
+      CGI::Cookie::new(
+        "name" => "foo",
+        "value" => "bar",
+        "domain" => "example.com",
+        "path" => "/"
+      ),
+      CGI::Cookie::new(
+        "name" => key,
+        "value" => value,
+        "domain" => "example.com",
+        "path" => "/"
+      )
+    ].map { |c| c.to_s }
+    stub_header("set-cookie", cookies)
   end
 
-  it "detects the CMS" do
-    expect(subject.cms.keys.first).to eql(:wordpress)
+  context "stubbed body" do
+    subject do
+      body = <<-eos
+        <html>
+          <head>
+            <link rel='stylesheet' href='/wp-content/themes/foo/style.css type='text/css' media='all' />
+          </head>
+          <body>
+            <h1>Some page</h1>
+            <script>
+              jQuery(); googletag.pubads();
+            </script>
+            <script>
+              var _gaq=[['_setAccount','UA-12345678-1'],['_trackPageview']];
+              (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
+              g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
+              s.parentNode.insertBefore(g,s)}(document,'script'));
+            </script>
+          </body>
+        </html>
+      eos
+
+      stub_request(:get, "http://example.com/").
+        to_return(:status => 200, :body => body )
+      endpoint = SiteInspector::Endpoint.new("http://example.com")
+      SiteInspector::Endpoint::Sniffer.new(endpoint)
+    end
+
+    it "sniffs" do
+      sniff = subject.send(:sniff, :cms)
+      expect(sniff).to eql(:wordpress)
+    end
+
+    it "detects the CMS" do
+      expect(subject.framework).to eql(:wordpress)
+    end
+
+    it "detects the analytics" do
+      expect(subject.analytics).to eql(:google_analytics)
+    end
+
+    it "detects javascript" do
+      expect(subject.javascript).to eql(:jquery)
+    end
+
+    it "detects advertising" do
+      expect(subject.advertising).to eql(:adsense)
+    end
   end
 
-  it "detects the analytics" do
-    expect(subject.analytics.keys.first).to eql(:google_analytics)
-  end
+  context "no body" do
 
-  it "detects javascript" do
-    expect(subject.javascript.keys.first).to eql(:jquery)
-  end
+    subject do
+      stub_request(:get, "http://example.com/").
+        to_return(:status => 200, :body => "" )
 
-  it "detects advertising" do
-    expect(subject.advertising.keys.first).to eql(:adsense)
+      endpoint = SiteInspector::Endpoint.new("http://example.com")
+      SiteInspector::Endpoint::Sniffer.new(endpoint)
+    end
+
+    it "detects PHP" do
+      set_cookie("PHPSESSID", "1234")
+      expect(subject.framework).to eql(:php)
+    end
+
+    it "detects Expression Engine" do
+      set_cookie("exp_csrf_token", "1234")
+      expect(subject.framework).to eql(:expression_engine)
+    end
   end
 end


### PR DESCRIPTION
This pull request does a few things:

1. `Sniffer#cms` is now `Sniffer#framework` to be more inclusive
2. `Sniffer#framework` returns a symbol, not a hash
3. `Sniffer#framework` now detects PHP and Expression Engine (if no CMS is detected)
4. `Headers#cookies` now properly parses the raw cookie headers as sent from the server