### PR TITLE
Make checks thread safe, parallelize checks

### DIFF
--- a/lib/site-inspector.rb
+++ b/lib/site-inspector.rb
@@ -2,6 +2,7 @@ require 'open-uri'
 require 'addressable/uri'
 require 'public_suffix'
 require 'typhoeus'
+require 'parallel'
 require 'cliver'
 require 'cgi'
 
@@ -55,8 +56,9 @@ class SiteInspector
       }
     end
 
+    # Returns a thread-safe, memoized hydra instance
     def hydra
-      @hydra ||= Typhoeus::Hydra.new(max_concurrency: 4)
+      Typhoeus::Hydra.hydra
     end
   end
 end

--- a/lib/site-inspector/endpoint.rb
+++ b/lib/site-inspector/endpoint.rb
@@ -161,7 +161,7 @@ class SiteInspector
       checks = SiteInspector::Endpoint.checks.select { |c| options.keys.include?(c.name) }
       checks = SiteInspector::Endpoint.checks if checks.empty?
 
-      checks.each do |check|
+      Parallel.each(checks, :in_threads => 4) do |check|
         hash[check.name] = self.send(check.name).to_h
       end
 

--- a/site-inspector.gemspec
+++ b/site-inspector.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency("mercenary", "~> 0.3")
   s.add_dependency("colorator", "~> 0.1")
   s.add_dependency("cliver", "~> 0.3")
+  s.add_dependency("parallel", "~> 1.6")
   s.add_development_dependency("pry", "~> 0.10")
   s.add_development_dependency( "rake", "~> 10.4" )
   s.add_development_dependency( "rspec", "~> 3.2")


### PR DESCRIPTION
Fixes #65.

This roughly cuts the time to crawl a site in half and required some changes to how we memoize our Hydra instance in order to make it thread safe. TL;DR: `Typhoeus::Hydra.hyrdra` is thread safe, while `Typhoeus::Hydra.new` is not.

/cc https://github.com/oscardelben/firebase-ruby/issues/15, https://github.com/typhoeus/ethon/issues/85, https://github.com/typhoeus/ethon/issues/96