### PR TITLE
Prefer HEAD requsets

### DIFF
--- a/lib/site-inspector.rb
+++ b/lib/site-inspector.rb
@@ -50,6 +50,7 @@ class SiteInspector
         :followlocation => false,
         :timeout => SiteInspector.timeout,
         :accept_encoding => "gzip",
+        :method => :head,
         :headers => {
           "User-Agent" => "Mozilla/5.0 (compatible; SiteInspector/#{SiteInspector::VERSION}; +https://github.com/benbalter/site-inspector)"
         }

--- a/lib/site-inspector/checks/content.rb
+++ b/lib/site-inspector/checks/content.rb
@@ -40,7 +40,7 @@ class SiteInspector
 
       def prefetch
         return unless endpoint.up?
-        options = SiteInspector.typhoeus_defaults.merge(followlocation: true, method: :get)
+        options = SiteInspector.typhoeus_defaults.merge(followlocation: true)
         ["robots.txt", "sitemap.xml", "humans.txt", random_path].each do |path|
           request = Typhoeus::Request.new(URI.join(endpoint.uri, path), options)
           SiteInspector.hydra.queue(request)

--- a/lib/site-inspector/checks/content.rb
+++ b/lib/site-inspector/checks/content.rb
@@ -6,6 +6,12 @@ class SiteInspector
         endpoint.up? && endpoint.request(path: path, followlocation: true).success?
       end
 
+      # The default Check#response method is from a HEAD request
+      # The content check has a special response which includes the body from a GET request
+      def response
+        @response ||= endpoint.request(:method => :get)
+      end
+
       def document
         require 'nokogiri'
         @doc ||= Nokogiri::HTML response.body if response
@@ -34,7 +40,7 @@ class SiteInspector
 
       def prefetch
         return unless endpoint.up?
-        options = SiteInspector.typhoeus_defaults.merge(followlocation: true)
+        options = SiteInspector.typhoeus_defaults.merge(followlocation: true, method: :get)
         ["robots.txt", "sitemap.xml", "humans.txt", random_path].each do |path|
           request = Typhoeus::Request.new(URI.join(endpoint.uri, path), options)
           SiteInspector.hydra.queue(request)

--- a/spec/checks/site_inspector_endpoint_accessibility_spec.rb
+++ b/spec/checks/site_inspector_endpoint_accessibility_spec.rb
@@ -44,7 +44,7 @@ describe SiteInspector::Endpoint::Accessibility do
   context "with pa11y installed" do
 
     before do
-      stub_request(:get, "http://example.com/").to_return(:status => 200 )
+      stub_request(:head, "http://example.com/").to_return(:status => 200 )
     end
 
   end

--- a/spec/checks/site_inspector_endpoint_check_spec.rb
+++ b/spec/checks/site_inspector_endpoint_check_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe SiteInspector::Endpoint::Check do
 
   subject do
-    stub_request(:get, "http://example.com/").to_return(:status => 200)
+    stub_request(:head, "http://example.com/").to_return(:status => 200)
     endpoint = SiteInspector::Endpoint.new("http://example.com")
     SiteInspector::Endpoint::Check.new(endpoint)
   end

--- a/spec/checks/site_inspector_endpoint_content_spec.rb
+++ b/spec/checks/site_inspector_endpoint_content_spec.rb
@@ -14,6 +14,8 @@ describe SiteInspector::Endpoint::Content do
 
     stub_request(:get, "http://example.com/").
       to_return(:status => 200, :body => body )
+      stub_request(:head, "http://example.com/").
+        to_return(:status => 200 )
     endpoint = SiteInspector::Endpoint.new("http://example.com")
     SiteInspector::Endpoint::Content.new(endpoint)
   end
@@ -32,62 +34,62 @@ describe SiteInspector::Endpoint::Content do
   end
 
   it "knows when robots.txt exists" do
-    stub_request(:get, /http\:\/\/example.com\/[a-z0-9]{32}/i).to_return(:status => 404)
+    stub_request(:head, /http\:\/\/example.com\/[a-z0-9]{32}/i).to_return(:status => 404)
 
-    stub_request(:get, "http://example.com/robots.txt").
+    stub_request(:head, "http://example.com/robots.txt").
       to_return(:status => 200)
     expect(subject.robots_txt?).to eql(true)
   end
 
   it "knows when robots.txt doesn't exist" do
-    stub_request(:get, /http\:\/\/example.com\/[a-z0-9]{32}/i).to_return(:status => 404)
+    stub_request(:head, /http\:\/\/example.com\/[a-z0-9]{32}/i).to_return(:status => 404)
 
-    stub_request(:get, "http://example.com/robots.txt").
+    stub_request(:head, "http://example.com/robots.txt").
       to_return(:status => 404)
     expect(subject.robots_txt?).to eql(false)
   end
 
   it "knows when sitemap.xml exists" do
-    stub_request(:get, /http\:\/\/example.com\/[a-z0-9]{32}/i).to_return(:status => 404)
+    stub_request(:head, /http\:\/\/example.com\/[a-z0-9]{32}/i).to_return(:status => 404)
 
-    stub_request(:get, "http://example.com/sitemap.xml").
+    stub_request(:head, "http://example.com/sitemap.xml").
       to_return(:status => 200)
     expect(subject.sitemap_xml?).to eql(true)
   end
 
   it "knows when sitemap.xml exists" do
-    stub_request(:get, /http\:\/\/example.com\/[a-z0-9]{32}/i).to_return(:status => 404)
+    stub_request(:head, /http\:\/\/example.com\/[a-z0-9]{32}/i).to_return(:status => 404)
 
-    stub_request(:get, "http://example.com/sitemap.xml").
+    stub_request(:head, "http://example.com/sitemap.xml").
       to_return(:status => 404)
     expect(subject.sitemap_xml?).to eql(false)
   end
 
   it "knows when humans.txt exists" do
-    stub_request(:get, /http\:\/\/example.com\/[a-z0-9]{32}/i).to_return(:status => 404)
+    stub_request(:head, /http\:\/\/example.com\/[a-z0-9]{32}/i).to_return(:status => 404)
 
-    stub_request(:get, "http://example.com/humans.txt").
+    stub_request(:head, "http://example.com/humans.txt").
       to_return(:status => 200)
     expect(subject.humans_txt?).to eql(true)
   end
 
   it "knows when humans.txt doesn't exist" do
-    stub_request(:get, /http\:\/\/example.com\/[a-z0-9]{32}/i).to_return(:status => 404)
+    stub_request(:head, /http\:\/\/example.com\/[a-z0-9]{32}/i).to_return(:status => 404)
 
-    stub_request(:get, "http://example.com/humans.txt").
+    stub_request(:head, "http://example.com/humans.txt").
       to_return(:status => 200)
     expect(subject.humans_txt?).to eql(true)
   end
 
   context "404s" do
     it "knows when an endpoint returns a proper 404" do
-      stub_request(:get, /http\:\/\/example.com\/.*/).
+      stub_request(:head, /http\:\/\/example.com\/.*/).
         to_return(:status => 404)
       expect(subject.proper_404s?).to eql(true)
     end
 
     it "knows when an endpoint doesn't return a proper 404" do
-      stub_request(:get, /http\:\/\/example.com\/[a-z0-9]{32}/i).
+      stub_request(:head, /http\:\/\/example.com\/[a-z0-9]{32}/i).
         to_return(:status => 200)
       expect(subject.proper_404s?).to eql(false)
     end
@@ -99,8 +101,8 @@ describe SiteInspector::Endpoint::Content do
     end
 
     it "doesn't say something exists when there are no 404s" do
-      stub_request(:get, /http\:\/\/example.com\/[a-z0-9]{32}/i).to_return(:status => 200)
-      stub_request(:get, "http://example.com/humans.txt").to_return(:status => 200)
+      stub_request(:head, /http\:\/\/example.com\/[a-z0-9]{32}/i).to_return(:status => 200)
+      stub_request(:head, "http://example.com/humans.txt").to_return(:status => 200)
       expect(subject.humans_txt?).to eql(nil)
     end
   end

--- a/spec/checks/site_inspector_endpoint_cookies_spec.rb
+++ b/spec/checks/site_inspector_endpoint_cookies_spec.rb
@@ -4,7 +4,7 @@ describe SiteInspector::Endpoint::Cookies do
 
   context "without cookies" do
     subject do
-      stub_request(:get, "http://example.com/").
+      stub_request(:head, "http://example.com/").
         to_return(:status => 200, :body => "" )
       endpoint = SiteInspector::Endpoint.new("http://example.com")
       SiteInspector::Endpoint::Cookies.new(endpoint)
@@ -33,7 +33,7 @@ describe SiteInspector::Endpoint::Cookies do
         )
       ].map { |c| c.to_s }
 
-      stub_request(:get, "http://example.com/").
+      stub_request(:head, "http://example.com/").
         to_return(:status => 200, :body => "", :headers => { "set-cookie" => cookies })
       endpoint = SiteInspector::Endpoint.new("http://example.com")
       SiteInspector::Endpoint::Cookies.new(endpoint)
@@ -59,7 +59,7 @@ describe SiteInspector::Endpoint::Cookies do
         "foo=bar; domain=example.com; path=/; secure; HttpOnly",
         "foo2=bar2; domain=example.com; path=/"
       ]
-      stub_request(:get, "http://example.com/").
+      stub_request(:head, "http://example.com/").
         to_return(:status => 200, :body => "", :headers => { "set-cookie" => cookies })
       endpoint = SiteInspector::Endpoint.new("http://example.com")
       SiteInspector::Endpoint::Cookies.new(endpoint)

--- a/spec/checks/site_inspector_endpoint_dns_spec.rb
+++ b/spec/checks/site_inspector_endpoint_dns_spec.rb
@@ -4,7 +4,7 @@ require 'dnsruby'
 describe SiteInspector::Endpoint::Dns do
 
   subject do
-    stub_request(:get, "http://github.com/").to_return(:status => 200)
+    stub_request(:head, "http://github.com/").to_return(:status => 200)
     endpoint = SiteInspector::Endpoint.new("http://github.com")
     SiteInspector::Endpoint::Dns.new(endpoint)
   end

--- a/spec/checks/site_inspector_endpoint_headers_spec.rb
+++ b/spec/checks/site_inspector_endpoint_headers_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe SiteInspector::Endpoint::Headers do
 
   subject do
-    stub_request(:get, "http://example.com/").
+    stub_request(:head, "http://example.com/").
       to_return(:status => 200, :headers => { :foo => "bar" } )
     endpoint = SiteInspector::Endpoint.new("http://example.com")
     SiteInspector::Endpoint::Headers.new(endpoint)

--- a/spec/checks/site_inspector_endpoint_hsts_spec.rb
+++ b/spec/checks/site_inspector_endpoint_hsts_spec.rb
@@ -4,7 +4,7 @@ describe SiteInspector::Endpoint::Hsts do
 
   subject do
     headers = { "strict-transport-security" => "max-age=31536000; includeSubDomains;" }
-    stub_request(:get, "http://example.com/").
+    stub_request(:head, "http://example.com/").
       to_return(:status => 200, :headers => headers )
     endpoint = SiteInspector::Endpoint.new("http://example.com")
     SiteInspector::Endpoint::Hsts.new(endpoint)

--- a/spec/checks/site_inspector_endpoint_https_spec.rb
+++ b/spec/checks/site_inspector_endpoint_https_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe SiteInspector::Endpoint::Https do
 
   subject do
-    stub_request(:get, "https://example.com/").
+    stub_request(:head, "https://example.com/").
       to_return(:status => 200 )
     endpoint = SiteInspector::Endpoint.new("https://example.com")
     allow(endpoint.response).to receive(:return_code) { :ok }

--- a/spec/checks/site_inspector_endpoint_sniffer_spec.rb
+++ b/spec/checks/site_inspector_endpoint_sniffer_spec.rb
@@ -23,7 +23,10 @@ describe SiteInspector::Endpoint::Sniffer do
     ].map { |c| c.to_s }
 
     stub_request(:get, "http://example.com/").
-      to_return(:status => 200, :body => "", :headers => { "set-cookie" => cookies } )
+      to_return(:status => 200, :body => "" )
+
+    stub_request(:head, "http://example.com/").
+      to_return(:status => 200, :headers => { "set-cookie" => cookies } )
   end
 
   context "stubbed body" do
@@ -50,6 +53,9 @@ describe SiteInspector::Endpoint::Sniffer do
 
       stub_request(:get, "http://example.com/").
         to_return(:status => 200, :body => body )
+
+      stub_request(:head, "http://example.com/").
+          to_return(:status => 200)
       endpoint = SiteInspector::Endpoint.new("http://example.com")
       SiteInspector::Endpoint::Sniffer.new(endpoint)
     end
@@ -105,7 +111,10 @@ describe SiteInspector::Endpoint::Sniffer do
 
     it "detects cowboy" do
       stub_request(:get, "http://example.com/").
-        to_return(:status => 200, :body => "", :headers => { "server" => "Cowboy" } )
+        to_return(:status => 200, :body => "" )
+
+      stub_request(:head, "http://example.com/").
+        to_return(:status => 200, :headers => { "server" => "Cowboy" } )
 
       expect(subject.framework).to eql(:cowboy)
       expect(subject.open_source?).to eql(true)
@@ -128,7 +137,10 @@ describe SiteInspector::Endpoint::Sniffer do
       ].map { |c| c.to_s }
 
       stub_request(:get, "http://example.com/").
-        to_return(:status => 200, :body => "", :headers => { "set-cookie" => cookies } )
+        to_return(:status => 200, :body => "" )
+        
+      stub_request(:head, "http://example.com/").
+        to_return(:status => 200, :headers => { "set-cookie" => cookies } )
 
       expect(subject.framework).to eql(:coldfusion)
       expect(subject.open_source?).to eql(false)

--- a/spec/site_inspector_domain_spec.rb
+++ b/spec/site_inspector_domain_spec.rb
@@ -53,10 +53,10 @@ describe SiteInspector::Domain do
   end
 
   it "knows the canonical domain" do
-    stub_request(:get, "https://example.com/").to_return(:status => 500)
-    stub_request(:get, "https://www.example.com/").to_return(:status => 500)
-    stub_request(:get, "http://www.example.com/").to_return(:status => 200)
-    stub_request(:get, "http://example.com/").to_return(:status => 200)
+    stub_request(:head, "https://example.com/").to_return(:status => 500)
+    stub_request(:head, "https://www.example.com/").to_return(:status => 500)
+    stub_request(:head, "http://www.example.com/").to_return(:status => 200)
+    stub_request(:head, "http://example.com/").to_return(:status => 200)
     expect(subject.canonical_endpoint.to_s).to eql("http://example.com")
   end
 
@@ -75,7 +75,7 @@ describe SiteInspector::Domain do
         end
       end
 
-      stub_request(:get, "http://www.example.com/").to_return(:status => 200)
+      stub_request(:head, "http://www.example.com/").to_return(:status => 200)
 
       expect(subject.up?).to eql(true)
     end
@@ -91,19 +91,19 @@ describe SiteInspector::Domain do
 
   context "up" do
     it "considers a domain up if at least one endpoint is up" do
-      stub_request(:get, "https://example.com/").to_return(:status => 500)
-      stub_request(:get, "https://www.example.com/").to_return(:status => 500)
-      stub_request(:get, "http://example.com/").to_return(:status => 500)
-      stub_request(:get, "http://www.example.com/").to_return(:status => 200)
+      stub_request(:head, "https://example.com/").to_return(:status => 500)
+      stub_request(:head, "https://www.example.com/").to_return(:status => 500)
+      stub_request(:head, "http://example.com/").to_return(:status => 500)
+      stub_request(:head, "http://www.example.com/").to_return(:status => 200)
 
       expect(subject.up?).to eql(true)
     end
 
     it "doesn't consider a domain up if all endpoints are down" do
-      stub_request(:get, "https://example.com/").to_return(:status => 500)
-      stub_request(:get, "https://www.example.com/").to_return(:status => 500)
-      stub_request(:get, "http://example.com/").to_return(:status => 500)
-      stub_request(:get, "http://www.example.com/").to_return(:status => 500)
+      stub_request(:head, "https://example.com/").to_return(:status => 500)
+      stub_request(:head, "https://www.example.com/").to_return(:status => 500)
+      stub_request(:head, "http://example.com/").to_return(:status => 500)
+      stub_request(:head, "http://www.example.com/").to_return(:status => 500)
 
       expect(subject.up?).to eql(false)
     end
@@ -111,19 +111,19 @@ describe SiteInspector::Domain do
 
   context "www" do
     it "considers a site www when at least one endpoint is www" do
-      stub_request(:get, "https://example.com/").to_return(:status => 200)
-      stub_request(:get, "https://www.example.com/").to_return(:status => 500)
-      stub_request(:get, "http://example.com/").to_return(:status => 500)
-      stub_request(:get, "http://www.example.com/").to_return(:status => 200)
+      stub_request(:head, "https://example.com/").to_return(:status => 200)
+      stub_request(:head, "https://www.example.com/").to_return(:status => 500)
+      stub_request(:head, "http://example.com/").to_return(:status => 500)
+      stub_request(:head, "http://www.example.com/").to_return(:status => 200)
 
       expect(subject.www?).to eql(true)
     end
 
     it "doesn't consider a site www when no endpoint is www" do
-      stub_request(:get, "https://example.com/").to_return(:status => 200)
-      stub_request(:get, "https://www.example.com/").to_return(:status => 500)
-      stub_request(:get, "http://example.com/").to_return(:status => 200)
-      stub_request(:get, "http://www.example.com/").to_return(:status => 500)
+      stub_request(:head, "https://example.com/").to_return(:status => 200)
+      stub_request(:head, "https://www.example.com/").to_return(:status => 500)
+      stub_request(:head, "http://example.com/").to_return(:status => 200)
+      stub_request(:head, "http://www.example.com/").to_return(:status => 500)
 
       expect(subject.www?).to eql(false)
     end
@@ -131,19 +131,19 @@ describe SiteInspector::Domain do
 
   context "root" do
     it "considers a domain root if you can connect without www" do
-      stub_request(:get, "https://example.com/").to_return(:status => 200)
-      stub_request(:get, "https://www.example.com/").to_return(:status => 500)
-      stub_request(:get, "http://example.com/").to_return(:status => 500)
-      stub_request(:get, "http://www.example.com/").to_return(:status => 500)
+      stub_request(:head, "https://example.com/").to_return(:status => 200)
+      stub_request(:head, "https://www.example.com/").to_return(:status => 500)
+      stub_request(:head, "http://example.com/").to_return(:status => 500)
+      stub_request(:head, "http://www.example.com/").to_return(:status => 500)
 
       expect(subject.root?).to eql(true)
     end
 
     it "doesn't call a www-only domain root" do
-      stub_request(:get, "https://example.com/").to_return(:status => 500)
-      stub_request(:get, "https://www.example.com/").to_return(:status => 200)
-      stub_request(:get, "http://example.com/").to_return(:status => 500)
-      stub_request(:get, "http://www.example.com/").to_return(:status => 200)
+      stub_request(:head, "https://example.com/").to_return(:status => 500)
+      stub_request(:head, "https://www.example.com/").to_return(:status => 200)
+      stub_request(:head, "http://example.com/").to_return(:status => 500)
+      stub_request(:head, "http://www.example.com/").to_return(:status => 200)
 
       expect(subject.root?).to eql(false)
     end
@@ -151,38 +151,38 @@ describe SiteInspector::Domain do
 
   context "https" do
     it "knows when a domain supports https" do
-      stub_request(:get, "https://example.com/").to_return(:status => 200)
-      stub_request(:get, "https://www.example.com/").to_return(:status => 200)
-      stub_request(:get, "http://example.com/").to_return(:status => 200)
-      stub_request(:get, "http://www.example.com/").to_return(:status => 200)
+      stub_request(:head, "https://example.com/").to_return(:status => 200)
+      stub_request(:head, "https://www.example.com/").to_return(:status => 200)
+      stub_request(:head, "http://example.com/").to_return(:status => 200)
+      stub_request(:head, "http://www.example.com/").to_return(:status => 200)
       allow(subject.endpoints.first.https).to receive(:valid?) { true }
 
       expect(subject.https?).to eql(true)
     end
 
     it "knows when a domain doesn't support https" do
-      stub_request(:get, "https://example.com/").to_return(:status => 500)
-      stub_request(:get, "https://www.example.com/").to_return(:status => 500)
-      stub_request(:get, "http://example.com/").to_return(:status => 200)
-      stub_request(:get, "http://www.example.com/").to_return(:status => 200)
+      stub_request(:head, "https://example.com/").to_return(:status => 500)
+      stub_request(:head, "https://www.example.com/").to_return(:status => 500)
+      stub_request(:head, "http://example.com/").to_return(:status => 200)
+      stub_request(:head, "http://www.example.com/").to_return(:status => 200)
 
       expect(subject.https?).to eql(false)
     end
 
     it "considers HTTPS inforced when no http endpoint responds" do
-      stub_request(:get, "https://example.com/").to_return(:status => 200)
-      stub_request(:get, "https://www.example.com/").to_return(:status => 500)
-      stub_request(:get, "http://example.com/").to_return(:status => 500)
-      stub_request(:get, "http://www.example.com/").to_return(:status => 500)
+      stub_request(:head, "https://example.com/").to_return(:status => 200)
+      stub_request(:head, "https://www.example.com/").to_return(:status => 500)
+      stub_request(:head, "http://example.com/").to_return(:status => 500)
+      stub_request(:head, "http://www.example.com/").to_return(:status => 500)
 
       #expect(subject.enforces_https?).to eql(true)
     end
 
     it "doesn't consider HTTPS inforced when an http endpoint responds" do
-      stub_request(:get, "https://example.com/").to_return(:status => 200)
-      stub_request(:get, "https://www.example.com/").to_return(:status => 500)
-      stub_request(:get, "http://example.com/").to_return(:status => 500)
-      stub_request(:get, "http://www.example.com/").to_return(:status => 200)
+      stub_request(:head, "https://example.com/").to_return(:status => 200)
+      stub_request(:head, "https://www.example.com/").to_return(:status => 500)
+      stub_request(:head, "http://example.com/").to_return(:status => 500)
+      stub_request(:head, "http://www.example.com/").to_return(:status => 200)
 
       expect(subject.enforces_https?).to eql(false)
     end
@@ -199,20 +199,20 @@ describe SiteInspector::Domain do
   context "canonical" do
     context "www" do
       it "detects a domain as canonically www when root is down" do
-        stub_request(:get, "https://example.com/").to_return(:status => 500)
-        stub_request(:get, "https://www.example.com/").to_return(:status => 500)
-        stub_request(:get, "http://example.com/").to_return(:status => 500)
-        stub_request(:get, "http://www.example.com/").to_return(:status => 200)
+        stub_request(:head, "https://example.com/").to_return(:status => 500)
+        stub_request(:head, "https://www.example.com/").to_return(:status => 500)
+        stub_request(:head, "http://example.com/").to_return(:status => 500)
+        stub_request(:head, "http://www.example.com/").to_return(:status => 200)
 
         expect(subject.canonically_www?).to eql(true)
       end
 
       it "detects a domain as canonically www when root redirects" do
-        stub_request(:get, "https://example.com/").to_return(:status => 500)
-        stub_request(:get, "https://www.example.com/").to_return(:status => 500)
-        stub_request(:get, "http://example.com/").
+        stub_request(:head, "https://example.com/").to_return(:status => 500)
+        stub_request(:head, "https://www.example.com/").to_return(:status => 500)
+        stub_request(:head, "http://example.com/").
           to_return(:status => 301, :headers => { :location => "http://www.example.com" } )
-        stub_request(:get, "http://www.example.com/").to_return(:status => 200)
+        stub_request(:head, "http://www.example.com/").to_return(:status => 200)
 
         expect(subject.canonically_www?).to eql(true)
       end
@@ -220,21 +220,21 @@ describe SiteInspector::Domain do
 
     context "https" do
       it "detects a domain as canonically https when http is down" do
-        stub_request(:get, "https://example.com/").to_return(:status => 200)
-        stub_request(:get, "https://www.example.com/").to_return(:status => 200)
-        stub_request(:get, "http://example.com/").to_return(:status => 500)
-        stub_request(:get, "http://www.example.com/").to_return(:status => 500)
+        stub_request(:head, "https://example.com/").to_return(:status => 200)
+        stub_request(:head, "https://www.example.com/").to_return(:status => 200)
+        stub_request(:head, "http://example.com/").to_return(:status => 500)
+        stub_request(:head, "http://www.example.com/").to_return(:status => 500)
         allow(subject.endpoints.first.https).to receive(:valid?) { true }
 
         expect(subject.canonically_https?).to eql(true)
       end
 
       it "detects a domain as canonically https when http redirect" do
-        stub_request(:get, "https://example.com/").to_return(:status => 200)
-        stub_request(:get, "https://www.example.com/").to_return(:status => 200)
-        stub_request(:get, "http://example.com/").
+        stub_request(:head, "https://example.com/").to_return(:status => 200)
+        stub_request(:head, "https://www.example.com/").to_return(:status => 200)
+        stub_request(:head, "http://example.com/").
           to_return(:status => 301, :headers => { :location => "https://example.com" } )
-        stub_request(:get, "http://www.example.com/").to_return(:status => 500)
+        stub_request(:head, "http://www.example.com/").to_return(:status => 500)
         allow(subject.endpoints.first.https).to receive(:valid?) { true }
 
         expect(subject.canonically_https?).to eql(true)
@@ -244,11 +244,11 @@ describe SiteInspector::Domain do
 
   context "redirects" do
     it "knows when a domain redirects" do
-      stub_request(:get, "https://example.com/").to_return(:status => 500)
-      stub_request(:get, "https://www.example.com/").to_return(:status => 500)
-      stub_request(:get, "http://example.com/").
+      stub_request(:head, "https://example.com/").to_return(:status => 500)
+      stub_request(:head, "https://www.example.com/").to_return(:status => 500)
+      stub_request(:head, "http://example.com/").
         to_return(:status => 301, :headers => { :location => "http://foo.example.com" } )
-      stub_request(:get, "http://www.example.com/").to_return(:status => 500)
+      stub_request(:head, "http://www.example.com/").to_return(:status => 500)
 
       expect(subject.redirect?).to eql(true)
     end

--- a/spec/site_inspector_endpoint_spec.rb
+++ b/spec/site_inspector_endpoint_spec.rb
@@ -28,10 +28,10 @@ describe SiteInspector::Endpoint do
   end
 
   it "knows if an endpoint is http" do
-    stub_request(:get, "http://example.com/").
+    stub_request(:head, "http://example.com/").
       to_return(:status => 200, :body => "content")
 
-    stub_request(:get, "https://example.com/").
+    stub_request(:head, "https://example.com/").
       to_return(:status => 500, :body => "content")
 
     expect(subject.https?).to eql(false)
@@ -39,10 +39,10 @@ describe SiteInspector::Endpoint do
   end
 
   it "knows if an endpoint is https" do
-    stub_request(:get, "http://example.com/").
+    stub_request(:head, "http://example.com/").
       to_return(:status => 200, :body => "content")
 
-    stub_request(:get, "https://example.com/").
+    stub_request(:head, "https://example.com/").
       to_return(:status => 200, :body => "content")
 
     endpoint = SiteInspector::Endpoint.new("https://example.com")
@@ -60,7 +60,7 @@ describe SiteInspector::Endpoint do
   context "requests" do
 
     it "requests a URL" do
-      stub = stub_request(:get, "http://example.com/").
+      stub = stub_request(:head, "http://example.com/").
            to_return(:status => 200, :body => "content")
 
       expect(subject.request.body).to eql("content")
@@ -68,7 +68,7 @@ describe SiteInspector::Endpoint do
     end
 
     it "requests a requested path" do
-      stub = stub_request(:get, "http://example.com/foo").
+      stub = stub_request(:head, "http://example.com/foo").
            to_return(:status => 200, :body => "content")
 
       expect(subject.request(:path => "foo").body).to eql("content")
@@ -76,7 +76,7 @@ describe SiteInspector::Endpoint do
     end
 
     it "requests with typhoeus options" do
-      stub_request(:get, "http://example.com/").
+      stub_request(:head, "http://example.com/").
            to_return(:status => 301, :headers => { :location => "http://example.com/foo" } )
 
       response = subject.request(:followlocation => true)
@@ -84,7 +84,7 @@ describe SiteInspector::Endpoint do
     end
 
     it "returns the response" do
-      stub = stub_request(:get, "http://example.com/").
+      stub = stub_request(:head, "http://example.com/").
            to_return(:status => 200, :body => "content")
 
       expect(subject.response.body).to eql("content")
@@ -93,7 +93,7 @@ describe SiteInspector::Endpoint do
     end
 
     it "knows if there's a response" do
-      stub_request(:get, "http://example.com/").
+      stub_request(:head, "http://example.com/").
            to_return(:status => 200, :body => "content")
 
       expect(subject.responds?).to eql(true)
@@ -108,7 +108,7 @@ describe SiteInspector::Endpoint do
     end
 
     it "knows the response code" do
-      stub_request(:get, "http://example.com/").
+      stub_request(:head, "http://example.com/").
            to_return(:status => 200)
 
       expect(subject.response_code).to eql("200")
@@ -120,7 +120,7 @@ describe SiteInspector::Endpoint do
     end
 
     it "considers a 200 response code to be live and a response" do
-      stub_request(:get, "http://example.com/").
+      stub_request(:head, "http://example.com/").
            to_return(:status => 200)
 
       expect(subject.up?).to eql(true)
@@ -128,7 +128,7 @@ describe SiteInspector::Endpoint do
     end
 
     it "considers a 301 response code to be live and a response" do
-      stub_request(:get, "http://example.com/").
+      stub_request(:head, "http://example.com/").
            to_return(:status => 301)
 
       expect(subject.up?).to eql(true)
@@ -136,7 +136,7 @@ describe SiteInspector::Endpoint do
     end
 
     it "considers a 404 response code to be down but a response" do
-      stub_request(:get, "http://example.com/").
+      stub_request(:head, "http://example.com/").
            to_return(:status => 404)
 
       expect(subject.up?).to eql(false)
@@ -144,7 +144,7 @@ describe SiteInspector::Endpoint do
     end
 
     it "considers a 500 response code to be down but a response" do
-      stub_request(:get, "http://example.com/").
+      stub_request(:head, "http://example.com/").
            to_return(:status => 500)
 
       expect(subject.up?).to eql(false)
@@ -168,41 +168,41 @@ describe SiteInspector::Endpoint do
 
   context "redirects" do
     it "knows when there's a redirect" do
-      stub_request(:get, "http://example.com/").
+      stub_request(:head, "http://example.com/").
         to_return(:status => 301, :headers => { :location => "http://www.example.com" } )
 
       expect(subject.redirect?).to eql(true)
     end
 
     it "returns the redirect" do
-      stub_request(:get, "http://example.com/").
+      stub_request(:head, "http://example.com/").
         to_return(:status => 301, :headers => { :location => "http://www.example.com" } )
 
-      stub_request(:get, "http://www.example.com/").
+      stub_request(:head, "http://www.example.com/").
         to_return(:status => 200)
 
       expect(subject.redirect.uri.to_s).to eql("http://www.example.com")
     end
 
     it "handles relative redirects" do
-      stub_request(:get, "http://example.com/").
+      stub_request(:head, "http://example.com/").
            to_return(:status => 301, :headers => { :location => "/foo" } )
 
       expect(subject.redirect?).to eql(false)
     end
 
     it "handles relative redirects without a leading slash" do
-      stub_request(:get, "http://example.com/").
+      stub_request(:head, "http://example.com/").
            to_return(:status => 301, :headers => { :location => "foo" } )
 
       expect(subject.redirect?).to eql(false)
     end
 
     it "knows what it resolves to" do
-      stub_request(:get, "http://example.com/").
+      stub_request(:head, "http://example.com/").
         to_return(:status => 301, :headers => { :location => "http://www.example.com" } )
 
-      stub_request(:get, "http://www.example.com/").
+      stub_request(:head, "http://www.example.com/").
         to_return(:status => 200)
 
       expect(subject.redirect?).to eql(true)
@@ -210,7 +210,7 @@ describe SiteInspector::Endpoint do
     end
 
     it "detects external redirects" do
-      stub_request(:get, "http://example.com/").
+      stub_request(:head, "http://example.com/").
         to_return(:status => 301, :headers => { :location => "http://www.example.gov" } )
 
       expect(subject.redirect?).to eql(true)
@@ -218,7 +218,7 @@ describe SiteInspector::Endpoint do
     end
 
     it "knows internal redirects are not external redirects" do
-      stub_request(:get, "http://example.com/").
+      stub_request(:head, "http://example.com/").
         to_return(:status => 301, :headers => { :location => "https://example.com" } )
 
       expect(subject.external_redirect?).to eql(false)
@@ -233,7 +233,7 @@ describe SiteInspector::Endpoint do
     SiteInspector::Endpoint.checks.each do |check|
       it "responds to the #{check} check" do
 
-        stub_request(:get, "http://example.com/").
+        stub_request(:head, "http://example.com/").
           to_return(:status => 200)
 
         expect(subject.send(check.name)).to_not be_nil

--- a/spec/site_inspector_spec.rb
+++ b/spec/site_inspector_spec.rb
@@ -36,6 +36,7 @@ describe SiteInspector do
     expected = {
       :accept_encoding => "gzip",
       :followlocation => false,
+      :method  => :head,
       :timeout => 10,
       :headers => {
         "User-Agent" => "Mozilla/5.0 (compatible; SiteInspector/#{SiteInspector::VERSION}; +https://github.com/benbalter/site-inspector)"


### PR DESCRIPTION
This pull requests moves the default HTTP verb from `GET` to `HEAD` to attempt to speed things up.

The only check that actually looks at the response body is the Content check. Checking, if, e.g., an endpoint responds, or what headers it returns, can be accomplished with a `HEAD` request, which, per the spec, should be identical to a `GET` request, just without the response body.

