### PR TITLE
WIP: Reduce the number of net calls made per check

### DIFF
--- a/lib/site-inspector.rb
+++ b/lib/site-inspector.rb
@@ -64,5 +64,11 @@ class SiteInspector
   end
 end
 
+if ENV["DEBUG"]
+  Ethon.logger = Logger.new(STDOUT);
+  Ethon.logger.level = Logger::DEBUG
+  Typhoeus::Config.verbose = true
+end
+
 Typhoeus::Config.memoize = true
 Typhoeus::Config.cache = SiteInspector.cache

--- a/lib/site-inspector/domain.rb
+++ b/lib/site-inspector/domain.rb
@@ -14,16 +14,19 @@ class SiteInspector
 
     def endpoints
       @endpoints ||= [
-        Endpoint.new("https://#{host}"),
-        Endpoint.new("https://www.#{host}"),
-        Endpoint.new("http://#{host}"),
-        Endpoint.new("http://www.#{host}")
+        Endpoint.new("https://#{host}", :domain => self),
+        Endpoint.new("https://www.#{host}", :domain => self),
+        Endpoint.new("http://#{host}", :domain => self),
+        Endpoint.new("http://www.#{host}", :domain => self)
       ]
     end
 
     def canonical_endpoint
-      @canonical_endpoint ||= endpoints.find do |e|
-        e.https? == canonically_https? && e.www? == canonically_www?
+      @canonical_endpoint ||= begin
+        prefetch
+        endpoints.find do |e|
+          e.https? == canonically_https? && e.www? == canonically_www?
+        end
       end
     end
 

--- a/lib/site-inspector/endpoint.rb
+++ b/lib/site-inspector/endpoint.rb
@@ -111,6 +111,10 @@ class SiteInspector
     def resolves_to
       return self unless redirect?
 
+      # If the redirect doesn't return a 30x response code, return the redirected endpoint
+      # Otherwise, we'll need to go down the rabbit hole and see how deep it goes
+      return redirect unless redirect.redirect?
+
       @resolves_to ||= begin
         response = request(:followlocation => true)
 

--- a/script/console
+++ b/script/console
@@ -1,1 +1,3 @@
-bundle exec pry -r ./lib/site-inspector.rb
+#! /bin/sh
+
+DEBUG=1 bundle exec pry -r './lib/site-inspector'

--- a/spec/site_inspector_domain_spec.rb
+++ b/spec/site_inspector_domain_spec.rb
@@ -45,10 +45,10 @@ describe SiteInspector::Domain do
     it "generates the endpoints" do
       endpoints = subject.endpoints
       expect(endpoints.count).to eql(4)
-      expect(endpoints[0].to_s).to eql("https://example.com")
-      expect(endpoints[1].to_s).to eql("https://www.example.com")
-      expect(endpoints[2].to_s).to eql("http://example.com")
-      expect(endpoints[3].to_s).to eql("http://www.example.com")
+      expect(endpoints[0].to_s).to eql("https://example.com/")
+      expect(endpoints[1].to_s).to eql("https://www.example.com/")
+      expect(endpoints[2].to_s).to eql("http://example.com/")
+      expect(endpoints[3].to_s).to eql("http://www.example.com/")
     end
   end
 
@@ -57,7 +57,7 @@ describe SiteInspector::Domain do
     stub_request(:head, "https://www.example.com/").to_return(:status => 500)
     stub_request(:head, "http://www.example.com/").to_return(:status => 200)
     stub_request(:head, "http://example.com/").to_return(:status => 200)
-    expect(subject.canonical_endpoint.to_s).to eql("http://example.com")
+    expect(subject.canonical_endpoint.to_s).to eql("http://example.com/")
   end
 
   it "knows if a domain is a government domain" do

--- a/spec/site_inspector_domain_spec.rb
+++ b/spec/site_inspector_domain_spec.rb
@@ -249,6 +249,7 @@ describe SiteInspector::Domain do
       stub_request(:head, "http://example.com/").
         to_return(:status => 301, :headers => { :location => "http://foo.example.com" } )
       stub_request(:head, "http://www.example.com/").to_return(:status => 500)
+      stub_request(:head, "http://foo.example.com/").to_return(:status => 200)
 
       expect(subject.redirect?).to eql(true)
     end

--- a/spec/site_inspector_endpoint_spec.rb
+++ b/spec/site_inspector_endpoint_spec.rb
@@ -15,7 +15,7 @@ describe SiteInspector::Endpoint do
   end
 
   it "returns the uri" do
-    expect(subject.uri.to_s).to eql("http://example.com")
+    expect(subject.uri.to_s).to eql("http://example.com/")
   end
 
   it "knows if an endpoint is www" do
@@ -181,7 +181,7 @@ describe SiteInspector::Endpoint do
       stub_request(:head, "http://www.example.com/").
         to_return(:status => 200)
 
-      expect(subject.redirect.uri.to_s).to eql("http://www.example.com")
+      expect(subject.redirect.uri.to_s).to eql("http://www.example.com/")
     end
 
     it "handles relative redirects" do
@@ -206,7 +206,7 @@ describe SiteInspector::Endpoint do
         to_return(:status => 200)
 
       expect(subject.redirect?).to eql(true)
-      expect(subject.resolves_to.uri.to_s).to eql("http://www.example.com")
+      expect(subject.resolves_to.uri.to_s).to eql("http://www.example.com/")
     end
 
     it "detects external redirects" do

--- a/spec/site_inspector_endpoint_spec.rb
+++ b/spec/site_inspector_endpoint_spec.rb
@@ -213,6 +213,9 @@ describe SiteInspector::Endpoint do
       stub_request(:head, "http://example.com/").
         to_return(:status => 301, :headers => { :location => "http://www.example.gov" } )
 
+      stub_request(:head, "http://www.example.gov").
+        to_return(:status => 200)
+
       expect(subject.redirect?).to eql(true)
       expect(subject.external_redirect?).to eql(true)
     end
@@ -220,6 +223,9 @@ describe SiteInspector::Endpoint do
     it "knows internal redirects are not external redirects" do
       stub_request(:head, "http://example.com/").
         to_return(:status => 301, :headers => { :location => "https://example.com" } )
+
+      stub_request(:head, "https://example.com/").
+        to_return(:status => 200)
 
       expect(subject.external_redirect?).to eql(false)
     end


### PR DESCRIPTION
Changes:

* Add debug mode via `DEBUG` config var which forces Typhoeus and Ethon into verbose output mode
* Prefetch endpoints (in parallel) before calculating a canonical endpoint
* Pass domain object to endpoint to facilitating caching when one endpoint redirects to another
* Calls to the root of an endpoint now have an explicit trailing slash to facilitate caching and prevent redirects
* `resolves_to` now makes a `HEAD` request to the redirected URL, which could be potentially cached, if an internal redirect, and only makes a follow location request if the `HEAD` request returns a `30x` response code.

Fixes #72.
